### PR TITLE
fix: replace sdk side NpTp function with a contract call

### DIFF
--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -174,10 +174,11 @@ class WrappedTransactionClass implements WrappedTransaction {
     // works with some L2 chains (Base, Polygon, Optimism)
     if (error?.error?.data) {
       const errorHash = error.error.data.data;
+
       return (
         this.getCustomErrorFromHash(contract, errorHash) ??
-        error.data.data?.cause ??
-        error.data.data?.message
+        error.error.data?.cause ??
+        error.error.data?.message
       );
     }
 


### PR DESCRIPTION
`calculateNpTpRatio` function gave slightly incorrect amount leading to incorrect liquidationBond size on Kick page
Replaced it with Pool contract call to borrowerInfo in `getLoan` and `getLoans` methods 